### PR TITLE
fix(workflow): require approval before compact check

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -37,29 +37,24 @@ Design doc (WHAT) → Implementation plan (HOW) → Execution
    - Log: `./scripts/log-session.sh {chat_id} design_saved docs/plans/YYYY-MM-DD-<topic>-design.md`
 2. Send via `scripts/send-file.sh` for review
 3. **Explicit confirmation required** - Wait for approval signal
-4. If approved → invoke `writing-plans` skill
-5. If changes → revise and resend
+4. **After approval, check for compact:**
+   ```bash
+   DOC_FILE="docs/plans/YYYY-MM-DD-<topic>-design.md"
+   if [ "$(./scripts/check-doc-size.sh "$DOC_FILE")" = "recommend" ]; then
+     SIZE_KB=$(du -k "$DOC_FILE" | cut -f1)
+     reply "Design approved. Doc is large (${SIZE_KB}KB). Consider /compact to free context before planning."
+   else
+     reply "Design approved. Ready for planning phase."
+   fi
+   ```
+5. If approved → invoke `writing-plans` skill
+6. If changes → revise and resend
 
 **Approval signals:** "approved", "looks good", "yes proceed", "LGTM"
 
 **Do NOT proceed** without explicit approval. If uncertain, ask: "Approve this design? (yes/no/request changes)"
 
-## After Design Saved
-
-After saving the design doc, check if it's large and recommend compact:
-
-```bash
-# Check if design doc is large
-DOC_FILE="docs/plans/YYYY-MM-DD-<topic>-design.md"  # Use actual filename
-if [ "$(./scripts/check-doc-size.sh "$DOC_FILE")" = "recommend" ]; then
-  SIZE_KB=$(du -k "$DOC_FILE" | cut -f1)
-  reply "Design saved. Doc is large (${SIZE_KB}KB). Consider /compact to free context before planning."
-else
-  reply "Design saved. Ready for planning phase."
-fi
-```
-
-Replace `YYYY-MM-DD-<topic>-design.md` with the actual design file path.
+**IMPORTANT:** Only check for compact AFTER user approval, not before.
 
 ## Key Principles
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -23,29 +23,32 @@ Before saving, verify:
 
 See `.claude/skills/writing-plans/references/plan-template.md` for template.
 
-## Execution Handoff
+## Plan Approval Flow
 
-See `.claude/skills/writing-plans/references/handoff-template.md` for handoff scripts.
+Plan → Review → Approval → Compact check → Execution
 
-## After Plan Saved
+1. Save plan to `docs/plans/YYYY-MM-DD-<feature>-plan.md`
+   - Log: `./scripts/log-session.sh {chat_id} plan_saved docs/plans/YYYY-MM-DD-<feature>-plan.md`
+2. Send via `scripts/send-file.sh` for review
+3. **Explicit confirmation required** - Wait for approval signal
+4. **After approval, check for compact:**
+   ```bash
+   PLAN_FILE="docs/plans/YYYY-MM-DD-<feature>-plan.md"
+   if [ "$(./scripts/check-doc-size.sh "$PLAN_FILE")" = "recommend" ]; then
+     SIZE_KB=$(du -k "$PLAN_FILE" | cut -f1)
+     reply "Plan approved. Doc is large (${SIZE_KB}KB). Consider /compact to free context before execution."
+   else
+     reply "Plan approved. Ready for execution phase."
+   fi
+   ```
+5. If approved → User triggers execution (manually or via command)
+6. If changes → Revise and resend
 
-After saving the implementation plan, check if it's large and recommend compact:
+**Approval signals:** "approved", "looks good", "yes proceed", "LGTM", "execute"
 
-```bash
-# Check if plan doc is large
-PLAN_FILE="docs/plans/YYYY-MM-DD-<feature>-plan.md"  # Use actual filename
-if [ "$(./scripts/check-doc-size.sh "$PLAN_FILE")" = "recommend" ]; then
-  SIZE_KB=$(du -k "$PLAN_FILE" | cut -f1)
-  reply "Plan saved. Doc is large (${SIZE_KB}KB). Consider /compact to free context before execution."
-else
-  reply "Plan saved. Ready for execution."
-fi
+**Do NOT proceed** without explicit approval. If uncertain, ask: "Approve this plan? (yes/no/request changes)"
 
-# Log plan save for session tracking
-./scripts/log-session.sh {chat_id} plan_saved docs/plans/YYYY-MM-DD-<feature>-plan.md
-```
-
-Replace `YYYY-MM-DD-<feature>-plan.md` with the actual plan file path.
+**IMPORTANT:** Only check for compact AFTER user approval, not before.
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

Fixes issue where compact check was running immediately after saving design/plan docs, bypassing user approval step.

## Problem

**Before:** Compact check ran immediately after saving → auto-proceeded without approval ❌

```
Save design → Send for review → IMMEDIATELY check compact → auto-proceed
```

**After:** Wait for approval FIRST, then check compact ✅

```
Save design → Send for review → WAIT FOR APPROVAL → Check compact → Proceed
```

## Changes

- **brainstorming**: Move compact check to AFTER approval step
- **writing-plans**: Add approval flow, move compact check to AFTER approval
- Add **IMPORTANT** note: Only check compact AFTER user approval

## Approval Signals

Users can approve with:
- "approved"
- **LGTM** ("Looks Good To Me")
- "looks good"
- "yes proceed"
- "execute" (for plans)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>